### PR TITLE
userManager with shadowsocks-plus HTTP API

### DIFF
--- a/ss_add_db.sh
+++ b/ss_add_db.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# jm33_m0
+
+path=~/ss/
+if ! test -e ~/ss; then
+    echo "
+[*] Creating Shadowsocks folder at $path
+"
+    mkdir -p ~/ss
+fi
+if [ "$1" != "-i" ]; then
+    if [ "$1" == '' ]; then
+        echo '
+[*] Usage: '$0' <-i> <user> <port> <password> <http api key>
+'
+        exit 0
+    fi
+    user=$1
+    port=$2
+    password=$3
+	apiKey=$4
+else
+    echo '
+[*] Now lets create a Shadowsocks user account
+'
+    echo -n 'Username: '
+    read user
+    echo -n 'Port: '
+    read port
+    echo -n 'Password: '
+    read password
+	echo -n "SSPlus HTTP API Key: "
+	read apiKey
+fi
+
+if ! test -e /var/log/ss; then
+    mkdir -p /var/log/ss
+fi
+
+cat << EOF >> $path/users.cfg
+$user:$port:$password
+EOF
+
+echo '
+[*] Now lets apply our changes and check if theres anything wrong...
+'
+
+$path/loadUserDatabase $path/users.cfg 127.0.0.1:5333 $apiKey
+
+netstat -anp | grep ":::$port" > /dev/null
+if [ $? -eq 0 ]; then
+    echo '
+[-] Something went wrong...
+'
+else
+    echo '
+[+] Success!
+'
+fi

--- a/userManager/loadUserDatabase.go
+++ b/userManager/loadUserDatabase.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"strconv"
+
+	"github.com/losfair/urlencoder-go/urlencoder"
+)
+
+type UserDetail struct {
+	Port string
+	Password string
+}
+
+func getUsage() string {
+	return "Usage: loadUserDatabase [path to database file] [ssplus api addr] [ssplus api key]"
+}
+
+func addUser(apiAddr,apiKey,port,pw string) {
+	reqStr := fmt.Sprintf("http://%s/%s/addUser/port=%s&pw=%s",apiAddr,apiKey,urlencoder.EncodeComponent(port),urlencoder.EncodeComponent(pw))
+	resp,err := http.Get(reqStr)
+	if err!=nil {
+		panic(err)
+	}
+
+	defer resp.Body.Close()
+	data,err := ioutil.ReadAll(resp.Body)
+	if err!=nil {
+		panic(err)
+	}
+
+	fmt.Println("[api]",string(data))
+}
+
+func main() {
+	if len(os.Args)<4 {
+		panic(getUsage())
+	}
+
+	fmt.Printf("Reading database... ")
+	os.Stdout.Sync()
+
+	userDatabaseName := os.Args[1]
+	userData,err := ioutil.ReadFile(userDatabaseName)
+	if err!=nil {
+		panic(err)
+	}
+
+	userLines := strings.Split(strings.TrimSpace(string(userData)),"\n")
+	userCfg := make(map[string]UserDetail)
+
+	for lineId,line := range userLines {
+		lineParts := strings.SplitN(strings.TrimSpace(line),":",3)
+		if len(lineParts)!=3 {
+			panic("Illegal configuration at line "+strconv.Itoa(lineId+1))
+		}
+		userCfg[lineParts[0]] = UserDetail {
+			Port: lineParts[1],
+			Password: lineParts[2],
+		}
+	}
+
+	fmt.Println("Done.")
+
+	fmt.Println("Adding users via API")
+
+	apiAddr := os.Args[2]
+	apiKey := os.Args[3]
+
+	for name,detail := range userCfg {
+		fmt.Printf("%s: ",name)
+		os.Stdout.Sync()
+		addUser(apiAddr,apiKey,detail.Port,detail.Password)
+	}
+
+	fmt.Println("Done.")
+}

--- a/userManager/testDatabase.txt
+++ b/userManager/testDatabase.txt
@@ -1,0 +1,3 @@
+User1:7701:Password1
+User2:7702:Password2
+


### PR DESCRIPTION
Add users without restarting ssplus server.
Better user management using a single text file.
```
User1:7701:Password1
User2:7702:Password2
```
Simple user configuration file like this should work.
Need to specify -api and -hkey while starting ssplus server.
Modified ss_add.sh to enable loadUserDatabase method at ss_add_db.sh, but haven't tested. Further modifications may be needed for the script to work.